### PR TITLE
Control zooming and panning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -506,11 +506,12 @@ async fn run(event_loop: EventLoop<AppEvent>, window: Window, mut app: PafViewer
                     WindowEvent::CursorMoved { position, .. } => {
                         let pos = DVec2::new(position.x, position.y);
                         if mouse_down {
-                            // TODO make panning 1-to-1
-                            // let vwidth = 2.0 / projection[0][0];
-                            // let vheight = 2.0 / projection[1][1];
                             if let Some(last) = last_pos {
                                 delta = (pos - last) * DVec2::new(1.0, -1.0);
+                                let win_size: [u32; 2] = window.inner_size().into();
+                                let dx = -delta.x * app_view.width() / win_size[0] as f64;
+                                let dy = -delta.y * app_view.height() / win_size[1] as f64;
+                                app_view.translate(dx, dy);
                             }
                             last_pos = Some(pos);
                         }
@@ -545,11 +546,13 @@ async fn run(event_loop: EventLoop<AppEvent>, window: Window, mut app: PafViewer
 
                         let screen_size = egui_renderer.context.screen_rect().size();
 
+                        /*
                         if delta.x != 0.0 || delta.y != 0.0 {
                             let dx = -delta.x * app_view.width() / win_size[0] as f64;
                             let dy = -delta.y * app_view.height() / win_size[1] as f64;
                             app_view.translate(dx, dy);
                         }
+                         */
 
                         if delta_scale != 1.0 {
                             if let Some(pos) = egui_renderer.context.pointer_latest_pos() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,30 +489,20 @@ async fn run(event_loop: EventLoop<AppEvent>, window: Window, mut app: PafViewer
                     WindowEvent::MouseWheel { delta, .. } => {
                         let zoom_factor = match delta {
                             winit::event::MouseScrollDelta::LineDelta(_, y) => y as f64,
-                            winit::event::MouseScrollDelta::PixelDelta(xy) => xy.y * 0.001,
+                            winit::event::MouseScrollDelta::PixelDelta(xy) => xy.y * 0.001_f64,
                         };
 
-                        let base_zoom_speed = 0.05; // Increased from 0.01 for faster default zoom
+                        let base_zoom_speed = 0.05_f64; // Increased from 0.01 for faster default zoom
                         let zoom_multiplier = if modifiers.state().shift_key() {
-                            10.0 // Fast zoom when Shift is pressed
+                            10.0_f64 // Fast zoom when Shift is pressed
                         } else if modifiers.state().control_key() {
-                            0.1 // Slow zoom when Ctrl is pressed
+                            0.1_f64 // Slow zoom when Ctrl is pressed
                         } else {
-                            1.0 // Normal zoom otherwise
+                            1.0_f64 // Normal zoom otherwise
                         };
 
                         delta_scale = 1.0 - zoom_factor * base_zoom_speed * zoom_multiplier;
                     },
-                            /*
-                    WindowEvent::MouseWheel { delta, phase, .. } => match delta {
-                        winit::event::MouseScrollDelta::LineDelta(x, y) => {
-                            delta_scale = 1.0 - y as f64 * 0.01;
-                        }
-                        winit::event::MouseScrollDelta::PixelDelta(xy) => {
-                            delta_scale = 1.0 - xy.y * 0.001;
-                        }
-                },
-                    */
                     WindowEvent::CursorMoved { position, .. } => {
                         let pos = DVec2::new(position.x, position.y);
                         if mouse_down {


### PR DESCRIPTION
This allows us to control the zoom speed using shift and control. So the default zoom is increased by fivefold. To achieve the old zoom level, you press control. And to speed up the zoom significantly, you press shift. This allows for rapid zooming in and out.